### PR TITLE
Use -j4 for slow jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,10 @@ jobs:
                     git submodule update --init --recursive
                     # Ensure we pull the latest image we just built
                     docker pull ghcr.io/mitchellthompkins/consteig_dev_image:latest
-                    export BUILD_SLOW_TESTS=1
+                    if [[ "${{ github.ref }}" == "refs/heads/main" || "${{ github.ref }}" == "refs/heads/develop" ]]; then
+                        export BUILD_SLOW_TESTS=1
+                    else
+                        export BUILD_SLOW_TESTS=0
+                    fi
                     make container.make.build
                     make container.make.test


### PR DESCRIPTION
Slow jobs in CI shouldn't be constrained by `-j 1`. They will run _slightly_ faster with -j 4.