### PR TITLE
Add parallel ctest Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ build: $(BUILD_PREFIX)/$(BUILD_FILE)
 	export CTEST_OUTPUT_ON_FAILURE=1; \
 	cmake --build $(BUILD_PREFIX) --target all -- $(JOB_FLAG) ${a}; \
 
-.PHONY: h
-h:
+.PHONY: help
+help:
 	@echo 'make [OPTIONS...] [TARGETS...]'
 	@echo
 	@echo 'TARGETS:'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a public test target to run the test suite in parallel for faster feedback.
  * Optimized test execution to use available processors, shortening overall test time.
  * Expanded build/test documentation with examples, environment setup, and rationale for per-test parallelism.
  * Updated test-related messaging to better reflect parallel ctest usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->