### PR TITLE
Do not make global ash_history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 build/
 compile_commands.json
 
+# container
+.ash_history
+
 # development
 *.sw[op]
 tags

--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ container.pull:
 
 .PHONY: container.start
 container.start:
-	touch $(HOME)/.consteig_ash_history
+	touch $(THIS_DIR)/.ash_history
 	docker compose -f docker-compose.yml run --rm dev_env 'sh -x'
 
 container.make.%:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
             - MY_GID=${MY_GID:? Error -> need GID.}
         volumes:
             - "${PWD}:${PWD}"
-            - "${HOME}/.consteig_ash_history:/home/${USER}/.ash_history"
+            - "${PWD}/.ash_history:/home/${USER}/.ash_history"
         network_mode: host
         tty: True
         working_dir: ${PWD}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated shell history file path configuration in development environment
  * Modified build system and container volume settings for history file tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->