### PR TITLE
Remove the flakely CI check for generated test cases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,21 +142,6 @@ jobs:
             - name: Cross-compile (static_assert is the test)
               run: make cross.${{ matrix.target }}
 
-    check-generated:
-        needs: build-and-publish-container
-        if: needs.build-and-publish-container.result == 'success'
-        runs-on: ubuntu-latest
-        container:
-          image: ghcr.io/mitchellthompkins/consteig_dev_image:${{ needs.build-and-publish-container.outputs.image_tag }}
-        permissions:
-          contents: read
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v6
-
-            - name: Verify generated test cases are up to date
-              run: make check-generated
-
     dc-motor-fail:
         needs: build-and-publish-container
         if: needs.build-and-publish-container.result == 'success'

--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,13 @@ generate-test-cases:
 	#                              all modern x86-64 CPUs used in CI.
 	OPENBLAS_NUM_THREADS=1 OPENBLAS_CORETYPE=ZEN3 octave octave/generate_test_cases.m
 
+# check-generated was removed from CI because it was non-deterministic (~1/5 runs
+# would fail) even with OPENBLAS_NUM_THREADS=1 and OPENBLAS_CORETYPE=ZEN3 set in
+# generate-test-cases. The matrix entries are reproducible (fixed RNG seed), but
+# the reference eigenvalues/eigenvectors in generated_cases.hpp come from Octave's
+# eig(), which calls LAPACK internally. LAPACK's eigensolver (dgeev/dsyev) can
+# produce bit-different results across runs due to internal scheduling and FMA
+# contraction behavior that OpenBLAS environment variables do not fully control.
 .PHONY: check-generated
 check-generated:
 	@SNAP=$$(mktemp -d); \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the `check-generated` verification job from the continuous integration workflow pipeline, including all associated dependencies on the container building step and conditional execution logic.
  * Added documentation comments to the build system configuration to clarify target assignments and workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->