### PR TITLE
Correct doxy linkage

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Install Doxygen 1.10.0 from upstream
         run: |
           wget -q https://github.com/doxygen/doxygen/releases/download/Release_1_10_0/doxygen-1.10.0.linux.bin.tar.gz
+          echo "dcfc9aa4cc05aef1f0407817612ad9e9201d9bf2ce67cecf95a024bba7d39747  doxygen-1.10.0.linux.bin.tar.gz" | sha256sum -c -
           tar -xzf doxygen-1.10.0.linux.bin.tar.gz
           sudo cp doxygen-1.10.0/bin/doxygen /usr/local/bin/doxygen
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,8 +27,14 @@ jobs:
       - name: Install Doxygen and Graphviz
         run: sudo apt-get install -y doxygen graphviz
 
+      - name: Print Doxygen version
+        run: doxygen --version
+
       - name: Generate Doxygen HTML
         run: doxygen docs/Doxyfile
+
+      - name: Remove polyfill.io from Doxygen output
+        run: find docs/api -name "*.html" -exec sed -i 's|<script src="https://polyfill\.io[^"]*"></script>||g' {} +
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,17 +24,24 @@ jobs:
       - name: Pull LFS objects
         run: git lfs pull
 
-      - name: Install Doxygen and Graphviz
-        run: sudo apt-get install -y doxygen graphviz
+      - name: Install Graphviz
+        run: sudo apt-get install -y graphviz
+
+      # Ubuntu 24.04 packages Doxygen 1.9.8 which generates HTML that loads from
+      # the compromised polyfill.io domain. The fix landed in 1.10.0. Install
+      # from upstream until Ubuntu ships a patched version.
+      # See: https://bugs.launchpad.net/ubuntu/+source/doxygen/+bug/2154796
+      - name: Install Doxygen 1.10.0 from upstream
+        run: |
+          wget -q https://github.com/doxygen/doxygen/releases/download/Release_1_10_0/doxygen-1.10.0.linux.bin.tar.gz
+          tar -xzf doxygen-1.10.0.linux.bin.tar.gz
+          sudo cp doxygen-1.10.0/bin/doxygen /usr/local/bin/doxygen
 
       - name: Print Doxygen version
         run: doxygen --version
 
       - name: Generate Doxygen HTML
         run: doxygen docs/Doxyfile
-
-      - name: Remove polyfill.io from Doxygen output
-        run: find docs/api -name "*.html" -exec sed -i 's|<script src="https://polyfill\.io[^"]*"></script>||g' {} +
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,9 +37,6 @@ jobs:
           tar -xzf doxygen-1.10.0.linux.bin.tar.gz
           sudo cp doxygen-1.10.0/bin/doxygen /usr/local/bin/doxygen
 
-      - name: Print Doxygen version
-        run: doxygen --version
-
       - name: Generate Doxygen HTML
         run: doxygen docs/Doxyfile
 


### PR DESCRIPTION
## Summary

* **Chores**
  * Updated documentation build process to enhance security and reliability of the documentation generation pipeline.

https://bugs.launchpad.net/ubuntu/+source/doxygen/+bug/2154796 (not public yet as of this writing) reports a security bug in doxygen that was causing the doxygen generated API reference link at https://mitchellthompkins.github.io/consteig/ to serve a malicious domain instead of the doxygen code.