### PR TITLE
Upgrade codecov.io action to fix failing gpg key

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -202,7 +202,7 @@ jobs:
               run: make coverage.gcc
 
             - name: Upload coverage reports to Codecov
-              uses: codecov/codecov-action@v7
+              uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # codecov/codecov-action@v7
               with:
                   use_oidc: true
                   files: build-coverage/coverage_filtered.info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -202,7 +202,7 @@ jobs:
               run: make coverage.gcc
 
             - name: Upload coverage reports to Codecov
-              uses: codecov/codecov-action@v5
+              uses: codecov/codecov-action@v7
               with:
                   use_oidc: true
                   files: build-coverage/coverage_filtered.info


### PR DESCRIPTION
See:

* https://github.com/codecov/codecov-action/issues/1876
* https://github.com/codecov/codecov-action/issues/1956

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal GitHub Actions workflow dependencies to latest stable versions for improved reliability and security in CI/CD processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->